### PR TITLE
Move implementation from .h to .cpp

### DIFF
--- a/MusicPlayer.cpp
+++ b/MusicPlayer.cpp
@@ -1041,4 +1041,20 @@ void MusicPlayer::midiDemoPlayer(void)
     }
 }
 
+void    MusicPlayer::setVolume(unsigned char volume) { vs1053.setVolume(volume, volume); _volume = volume; }
+void    MusicPlayer::setPlayMode(playMode_t playmode) { _playmode = playmode; }
+void    MusicPlayer::keyEnable(void)    { Key_Disable = 0; }
+void    MusicPlayer::keyDisable(void)   { Key_Disable = 1; }
+void    MusicPlayer::analogControlEnable(void)  { Analog_Enable = 1; }
+void    MusicPlayer::digitalControlEnable(void) { Digital_Enable = 1; }
 
+void    MusicPlayer::opPlay(void)   { playingState = PS_PRE_PLAY; }
+void    MusicPlayer::opPause(void)  { playingState = PS_PAUSE; }
+void    MusicPlayer::opResume(void) { playingState = PS_PLAY; }
+void    MusicPlayer::opStop(void)   { playingState = PS_IDLE; }
+void    MusicPlayer::opVolumeUp(void)     { ctrlState = CS_UP; }
+void    MusicPlayer::opVolumeDown(void)   { ctrlState = CS_DOWN; }
+void    MusicPlayer::opNextSong(void)     { ctrlState = CS_NEXT; }
+void    MusicPlayer::opPreviousSong(void) { ctrlState = CS_PREV; }
+void    MusicPlayer::opFastForward(void)  { ctrlState = CS_NEXT_LONG; }
+void    MusicPlayer::opFastRewind(void)   { ctrlState = CS_PREV_LONG; }

--- a/MusicPlayer.h
+++ b/MusicPlayer.h
@@ -156,14 +156,14 @@ public:
   void    attachDigitOperation(int pinNum, void (*userFunc)(void), int mode);
   void    attachAnalogOperation(int pinNum, void (*userFunc)(void));
 
-  void    setVolume(unsigned char volume) { vs1053.setVolume(volume, volume); _volume = volume;}
+  void    setVolume(unsigned char volume);
   void    adjustVolume(boolean UpOrDown, unsigned char NumSteps = 6);
-  void    setPlayMode(playMode_t playmode) { _playmode = playmode;}
+  void    setPlayMode(playMode_t playmode);
   boolean deleteSong(char *songName);
-  void    keyEnable(void)    { Key_Disable = 0;}
-  void    keyDisable(void)   { Key_Disable = 1;}
-  void    analogControlEnable(void) { Analog_Enable = 1;}
-  void    digitalControlEnable(void) { Digital_Enable = 1;}
+  void    keyEnable(void);
+  void    keyDisable(void);
+  void    analogControlEnable(void);
+  void    digitalControlEnable(void);
 
   void    play(void);
   void    midiDemoPlayer(void);

--- a/MusicPlayer.h
+++ b/MusicPlayer.h
@@ -166,17 +166,17 @@ public:
   void    digitalControlEnable(void) { Digital_Enable = 1;}
 
   void    play(void);
-  void    midiDemoPlayer(void);		//oliver wang
-  void    opPlay(void)  { playingState = PS_PRE_PLAY;}
-  void    opPause(void) { playingState = PS_PAUSE;}
-  void    opResume(void) { playingState = PS_PLAY;}
-  void    opStop(void)  { playingState = PS_IDLE;}
-  void    opVolumeUp()    {ctrlState = CS_UP;}
-  void    opVolumeDown(void)  { ctrlState = CS_DOWN;}
-  void    opNextSong(void)    { ctrlState = CS_NEXT;}
-  void    opPreviousSong(void) { ctrlState = CS_PREV;}
-  void    opFastForward() {ctrlState = CS_NEXT_LONG;}
-  void    opFastRewind()  {ctrlState = CS_PREV_LONG;}
+  void    midiDemoPlayer(void);
+  void    opPlay(void);
+  void    opPause(void);
+  void    opResume(void);
+  void    opStop(void);
+  void    opVolumeUp(void);
+  void    opVolumeDown(void);
+  void    opNextSong(void);
+  void    opPreviousSong(void);
+  void    opFastForward(void);
+  void    opFastRewind(void);
   void    _hardtime_update(void);
 
 private:
@@ -203,11 +203,11 @@ private:
   void    controlLED(void);
   boolean playlistIsFull(void);
   boolean _inPlayList(uint16_t);
-  void    _play();
+  void    _play(void);
   void    LoadUserCode(void);
   void    _preRecording(void);
   void    _recording(void);
-  void    _init_timer1();
+  void    _init_timer1(void);
 
   //for Midi Player
   void midiWriteData(byte cmd, byte high, byte low);


### PR DESCRIPTION
Current version would cause a linker error, tested on Arduino IDE 1.6.5. This pull could fix it.
