### PR TITLE
Fix case of filename in #include directive

### DIFF
--- a/pins_config.h
+++ b/pins_config.h
@@ -33,7 +33,7 @@
 #define PINS_CONFIG_H
 
 #include <avr/io.h>
-#include <arduino.h>
+#include <Arduino.h>
 ////////////////////For some control pins//////////////////////////
 #define ROTARY_ANGLE_SENSOR A4
 #define BUTTON              7


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.